### PR TITLE
Converted to UTF-8

### DIFF
--- a/lagesonum/views/footer.tpl
+++ b/lagesonum/views/footer.tpl
@@ -1,4 +1,4 @@
-Diese Seite befindet sich noch im Testbetrieb. Es können unerwartete Störungen auftreten. Wir bitten um Entschuldigung.
+Diese Seite befindet sich noch im Testbetrieb. Es kÃ¶nnen unerwartete StÃ¶rungen auftreten. Wir bitten um Entschuldigung.
 This website is still being tested. Unexpected errors may occur. We apologize for any inconvenience.
 
 </body></html>


### PR DESCRIPTION
Bottle used to spit DeprecationWarning all the time because of this file
being Latin1 instead of UTF-8.
