### PR TITLE
Simplify form submit paths

### DIFF
--- a/lagesonum/views/query_page.tpl
+++ b/lagesonum/views/query_page.tpl
@@ -6,7 +6,7 @@
 <p>{{_('search_pitch')}}</p>
 
 
-<form action="{{i18n_path('/query')}}" method="post" class="form-inline" style="margin-bottom:20px;">
+<form action="{{i18n_path(request.fullpath)}}" method="post" class="form-inline" style="margin-bottom:20px;">
   <div class="form-group">
     <label for="numberfield">{{_('txtnumber')}}</label>
     <input type="text" name="number" class="form-control" placeholder="{{_('queryexample')}}" id="numberfield">

--- a/lagesonum/views/start_page.tpl
+++ b/lagesonum/views/start_page.tpl
@@ -6,7 +6,7 @@
 
 <p>{{_(u'help_pitch')}}</p>
 
-<form action="{{i18n_path('/enter')}}" method="post">
+<form action="{{i18n_path(request.fullpath)}}" method="post">
   <div class="form-group">
     <textarea name="numbers" rows="10" class="form-control" placeholder="{{_('inputexample')}}"></textarea>
   </div>


### PR DESCRIPTION
Form submitting to current url (self) can be generalized by making use
of 'fullpath' information within request.
