### PR TITLE
Introduce session to save authentication state

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+Babel==2.1.1
+Beaker==1.7.0
 beautifulsoup4==4.4.0
 bottle==0.12.8
 bottle-i18n==0.1.5
@@ -15,9 +17,9 @@ bottle-utils-meta==0.3.2
 nose==1.3.7
 passlib==1.6.5
 peewee==2.6.4
+pycrypto==2.6.1
 python-dateutil==2.4.2
 six==1.9.0
 waitress==0.8.10
 WebOb==1.4.1
 WebTest==2.0.18
-Babel==2.1.1


### PR DESCRIPTION
If user was authenticated once it's state is saved in encrypted and
signed cookie, so password verification is done only once.

Session is configured to be cookie-only, i.e. no persistence and no
session data after process restart.

Session encryption and validation keys are elaborated on process startup
from random data.
