### PR TITLE
More static view for authenticated enter

### DIFF
--- a/lagesonum/bottle_app.py
+++ b/lagesonum/bottle_app.py
@@ -85,6 +85,10 @@ def enter():
 @route('/enter', method='POST')
 @view('views/start_page')
 def do_enter():
+    return enter_save()
+
+
+def enter_save():
     """Enter numbers into database"""
     numbers = set(parse_numbers(request.forms.get('numbers', '')))
     timestamp = datetime.datetime.now()
@@ -255,16 +259,16 @@ def check_username(username, password):
 
 @route('/authenticated')
 @auth_basic(check_username, realm='Authenticated access', text='Please authenticate to enter')
-@view('views/start_page', entered=[])
+@view('views/start_page_authed', entered=[])
 def authenticated():
     pass
 
 
 @route('/authenticated', method='POST')
 @auth_basic(check_username, realm='Authenticated access', text='Please authenticate to enter')
-@view('views/start_page')
+@view('views/start_page_authed')
 def do_authenticated():
-    return do_enter()
+    return enter_save()
 
 
 @route('/version', no_i18n=True)

--- a/lagesonum/views/start_page_authed.tpl
+++ b/lagesonum/views/start_page_authed.tpl
@@ -1,0 +1,27 @@
+% include('views/header.tpl')
+
+
+<div class="container">
+      <div class="starter-template">
+
+<p>Bitte helfen Sie mit, diese Seite aktuell zu erhalten, indem Sie alle Nummern, die auf der Anzeigetafel stehen - oder in absehbarer Zeit dort erscheinen werden - eingeben:</p>
+
+<form action="{{i18n_path(request.fullpath)}}" method="post">
+  <div class="form-group">
+    <textarea name="numbers" rows="10" class="form-control" placeholder="z.B. A123  BC34 AX99"></textarea>
+  </div>
+  <button class="btn btn-primary">Abschicken</button>
+</form>
+
+<ul>
+% if entered:
+    Herzlichen Dank! Sie haben die folgenden Wartenummern erfolgreich in die Datenbank eingetragen:
+    % for number in entered:
+    <li> <b>{{number}}</b> [{{timestamp}}]</li>
+    % end
+% end
+</ul>
+</div>
+</div>
+
+% include('views/footer.tpl')


### PR DESCRIPTION
Goal is to not duplicate more than necessary, but nevertheless reflect
obligatory differences (e.g. German "Sie").

For reusing business code it had to be moved from decorated function, as
applied decorators overwrite different view settings, when called from
second function.

It's not perfect yet, especially "navbar" and "error texts" are still
internationalized (fixed to German would be preferred) and not "Sie"-ed
correctly. But maybe it's good enough for now.
