### PR TITLE
Enable language and language direction attributes

### DIFF
--- a/lagesonum/configuration.py
+++ b/lagesonum/configuration.py
@@ -3,10 +3,10 @@ MIN_COUNT = 3
 MAX_DAYS = 5
 
 # locales in alphabetical order
-LANGS = [    ('ar_SY', u'العربية', str.maketrans('1234567890', '١٢٣٤٥٦٧٨٩٠')),
-             ('de_DE', u'Deutsch', str.maketrans('1234567890', '1234567890')),
-             ('en_US', u'English', str.maketrans('1234567890', '1234567890')),
-             ('eo_EO', u'Esperanto', str.maketrans('1234567890', '1234567890'))
+LANGS = [    ('ar_SY', u'العربية', str.maketrans('1234567890', '١٢٣٤٥٦٧٨٩٠'), 'rtl'),
+             ('de_DE', u'Deutsch', str.maketrans('1234567890', '1234567890'), 'ltr'),
+             ('en_US', u'English', str.maketrans('1234567890', '1234567890'), 'ltr'),
+             ('eo_EO', u'Esperanto', str.maketrans('1234567890', '1234567890'), 'ltr'),
 #             ('fa_IR', u'?????'),
 #             ('prs_AF', u'???'),
 #             ('tr_TR', u'Türkçe'),

--- a/lagesonum/views/footer.tpl
+++ b/lagesonum/views/footer.tpl
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container" dir="ltr">
   <p class="alert alert-info">Diese Seite befindet sich noch im Testbetrieb. Es können unerwartete Störungen auftreten. Wir bitten um Entschuldigung.
 This website is still being tested. Unexpected errors may occur. We apologize for any inconvenience.</p>
 </div>

--- a/lagesonum/views/header.tpl
+++ b/lagesonum/views/header.tpl
@@ -1,7 +1,7 @@
 % setdefault('current_lang', [l for l in languages if l[0] == request.locale][0])
 
 <!DOCTYPE html>
-<html class="no-js" lang="">
+<html class="no-js" lang="{{current_lang[0][:1]}}" dir="{{current_lang[3]}}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -74,7 +74,7 @@
               <img src="/static/languages.png" alt="pick a language" width="20" height="20" class="navbar-lang-icon"> {{current_lang[1]}}<span class="caret"/>
             </a>
             <ul class="dropdown-menu">
-              % for (code, label, trans_table) in languages:
+              % for (code, label, trans_table, dir) in languages:
                 <li>
                   <a href="{{i18n_path(request.path, code)}}">
                     {{label}}


### PR DESCRIPTION
For Right-To-Left languages HTML markup should contain appropriate
information, to come closer towards "real" i18n.
