### PR TITLE
Change session storage to DB backend

### DIFF
--- a/lagesonum/bottle_app.py
+++ b/lagesonum/bottle_app.py
@@ -2,7 +2,6 @@
 
 import os
 import datetime
-import random
 import subprocess
 from babel.dates import format_datetime
 from babel.core import Locale, UnknownLocaleError
@@ -295,9 +294,9 @@ application = I18NPlugin(app, langs=LANGS, default_locale=DEFAULT_LOCALE,
                          locale_dir=os.path.join(MOD_PATH, 'locales'))
 session_opts = {
     'session.key': 'lagesonum_sess',
-    'session.type': 'cookie',
-    'session.encrypt_key': '{:x}'.format(random.randrange(16**128)),
-    'session.validate_key': '{:x}'.format(random.randrange(16**32)),
+    'session.type': 'ext:database',
+    'session.url': 'sqlite:///' + DB_PATH,
+    'session.table_name': 'session_storage',
     'session.cookie_expires': 1800,
     'session.httponly': True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,9 @@ bottle-utils-meta==0.3.2
 nose==1.3.7
 passlib==1.6.5
 peewee==2.6.4
-pycrypto==2.6.1
 python-dateutil==2.4.2
 six==1.9.0
+SQLAlchemy==1.0.8
 waitress==0.8.10
 WebOb==1.4.1
 WebTest==2.0.18

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 bottle-werkzeug==0.1
 coverage==4.0
+sqlalchemy-sql-shell==0.0.0
 Werkzeug==0.10.4


### PR DESCRIPTION
PyCrypto works, but seems to be problematic to install.
Switching to cookies referencing DB stored session data, instead of
cryptographically secured cookies, containing relevant information.
