### PR TITLE
Switched ORM to SQLAlchemy

### DIFF
--- a/lagesonum/models.py
+++ b/lagesonum/models.py
@@ -1,80 +1,63 @@
 # coding: utf-8
 
 from datetime import datetime
-from peewee import *
+
+from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime, ForeignKey, Index, UniqueConstraint
+from sqlalchemy.orm import relationship, backref, sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+Session = sessionmaker(autocommit=False)
 
 
-class BaseModel(Model):
+class BaseModel():
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if 'database' in kwargs:
-            self._meta.database.init(database=kwargs['database'])
-            self.connect()
-            User.create_table(fail_silently=True)
-            Place.create_table(fail_silently=True)
-            Number.create_table(fail_silently=True)
+    def __init__(self, database, **kwargs):
+        super().__init__()
+        self.engine = create_engine('sqlite:///{}'.format(database), echo=True)
+        Base.metadata.create_all(self.engine)
+        Session.configure(bind=self.engine)
 
-    def connect(self):
-        if self._meta.database.is_closed():
-            self._meta.database.connect()
-
-    def disconnect(self):
-        if not self._meta.database.is_closed():
-            self._meta.database.close()
-
-    def commit(self):
-        self._meta.database.commit()
-
-    def rollback(self):
-        self._meta.database.rollback()
-
-    @property
-    def autocommit(self):
-        return self._meta.database.autocommit
-
-    @autocommit.setter
-    def autocommit(self, autocommit):
-        self._meta.database.autocommit = autocommit
-
-    class Meta:
-        database = SqliteDatabase(None)
+    def create_session(self):
+        return Session()
 
 
-class User(BaseModel):
-    id = PrimaryKeyField()
-    username = CharField(unique=True, max_length=10)
-    password = CharField(max_length=256)
-    is_admin = BooleanField(default=False)
+class User(Base, BaseModel):
+    __tablename__ = 'user'
 
-    @classmethod
-    def create_table(cls, fail_silently=False):
-        super().create_table(fail_silently)
+    id = Column('id', Integer, primary_key=True)
+    username = Column('username', String(25), unique=True)
+    password = Column('password', String(256))
+    is_admin = Column('is_admin', Boolean, default=False)
 
-
-class Place(BaseModel):
-    id = PrimaryKeyField()
-    valregexp = CharField(max_length=99, default=None)
-    place = CharField(max_length=20)
-    min_length = IntegerField(default=0)
-    max_length = IntegerField(default=10)
-
-    @classmethod
-    def create_table(cls, fail_silently=False):
-        super().create_table(fail_silently)
-        if not Place.select(Place.place == 'LAGESO').exists():
-            Place.create(place='LAGESO', valregexp=r'\b[a-z0-9]{4}\b')
+    def __repr__(self):
+        return u'User: {}, admin={}'.format(self.username, self.is_admin)
 
 
-class Number(BaseModel):
-    id = PrimaryKeyField()
-    number = CharField(max_length=30, null=False)
-    time = DateTimeField(default=datetime.now)
-    user = ForeignKeyField(User, null=True)
-    place = ForeignKeyField(Place)
-    fingerprint = CharField(max_length=32)
+class Place(Base, BaseModel):
+    __tablename__ = 'place'
 
-    class Meta:
-        indexes = (
-            (('number', 'fingerprint'), True),
-        )
+    id = Column('id', Integer, primary_key=True)
+    validation = Column('valregexp', String(99))
+    name = Column('place', String(20), index=True)
+
+    def __repr__(self):
+        return u'Place: {} ({})'.format(self.name, self.validation)
+
+
+class Number(Base, BaseModel):
+    __tablename__ = 'number'
+
+    id = Column('id', Integer, primary_key=True)
+    number = Column('number', String(30))
+    timestamp = Column('time', DateTime, default=datetime.now())
+    user_id = Column('user_id', ForeignKey('user.id'))
+    place_id = Column('place_id', ForeignKey('place.id'))
+    fingerprint = Column('fingerprint', String(32))
+    UniqueConstraint('number', 'fingerprint', name='number_fingerprint')
+
+    user = relationship('User')
+    place = relationship('Place')
+
+    def __repr__(self):
+        return u'Number: {} ({})'.format(self.number, self.timestamp, self.user)

--- a/lagesonum/views/start_page.tpl
+++ b/lagesonum/views/start_page.tpl
@@ -17,7 +17,7 @@
 
 % if entered:
 <div class="para">
-{{_('entered')}} [{{locale_datetime(timestamp).translate(locale_translate)}}]:
+{{_('entered')}} [{{locale_translate(locale_datetime(timestamp))}}]:
 <ul>
 % for number in entered:
     <li><b>{{number}}</b></li>

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ bottle-utils-lazy==0.3.2
 bottle-utils-meta==0.3.2
 nose==1.3.7
 passlib==1.6.5
+pycrypto==2.6.1
 peewee==2.6.4
 python-dateutil==2.4.2
 six==1.9.0


### PR DESCRIPTION
When using DB backend for Beaker, we're enforced to have SQLAlchemy
present.
There's no point in using peewee for our own ORM - it's too simple
data model, to justify a special ORM.

So reuse what's there nevertheless.
